### PR TITLE
Some changes to make the Kyber impl more consistent with the stdlib

### DIFF
--- a/lib/std/crypto.zig
+++ b/lib/std/crypto.zig
@@ -66,13 +66,9 @@ pub const dh = struct {
     pub const X25519 = @import("crypto/25519/x25519.zig").X25519;
 };
 
-const kyber = @import("crypto/kyber.zig");
-
 /// Key Encapsulation Mechanisms.
 pub const kem = struct {
-    pub const Kyber512 = kyber.Kyber512;
-    pub const Kyber768 = kyber.Kyber768;
-    pub const Kyber1024 = kyber.Kyber1024;
+    pub const kyber = @import("crypto/kyber.zig");
 };
 
 /// Elliptic-curve arithmetic.
@@ -226,7 +222,7 @@ test {
 
     _ = dh.X25519;
 
-    _ = kyber;
+    _ = kem.kyber;
 
     _ = ecc.Curve25519;
     _ = ecc.Edwards25519;

--- a/lib/std/crypto/kyber.zig
+++ b/lib/std/crypto/kyber.zig
@@ -196,7 +196,7 @@ fn Kyber(comptime p: Params) type {
             // Cached
             hpk: [h_length]u8, // H(pk)
 
-            pub const packet_length: usize = InnerPk.packed_length;
+            pub const packed_length: usize = InnerPk.packed_length;
 
             /// Generates a shared secret, written to ss, and encapsulates
             /// it for public key, written to ct.
@@ -241,11 +241,11 @@ fn Kyber(comptime p: Params) type {
                 kdf.squeeze(ss);
             }
 
-            pub fn pack(pk: PublicKey) [packet_length]u8 {
+            pub fn pack(pk: PublicKey) [packed_length]u8 {
                 return pk.pk.pack();
             }
 
-            pub fn unpack(buf: *const [packet_length]u8) PublicKey {
+            pub fn unpack(buf: *const [packed_length]u8) PublicKey {
                 var ret: PublicKey = undefined;
                 ret.pk = InnerPk.unpack(buf[0..InnerPk.packed_length]);
 
@@ -1001,7 +1001,7 @@ const Poly = struct {
     fn compress(p: Poly, comptime d: u8) [compressedSize(d)]u8 {
         @setEvalBranchQuota(10000);
         const q_over_2: u32 = comptime @divTrunc(Q, 2); // (q-1)/2
-        const two_dm_1: u32 = comptime (1 << d) - 1; // 2ᵈ-1
+        const two_d_min_1: u32 = comptime (1 << d) - 1; // 2ᵈ-1
         var in_off: usize = 0;
         var out_off: usize = 0;
 
@@ -1023,7 +1023,7 @@ const Poly = struct {
                 //                  = ⌊((x << d) + q/2) / q⌋ mod⁺ 2ᵈ
                 //                  = DIV((x << d) + q/2, q) & ((1<<d) - 1)
                 const t = @intCast(u32, p.cs[in_off + i]) << d;
-                in[i] = @intCast(u16, @divFloor(t + q_over_2, Q) & two_dm_1);
+                in[i] = @intCast(u16, @divFloor(t + q_over_2, Q) & two_d_min_1);
             }
 
             // Now we pack the d-bit integers from `in' into out as bytes.

--- a/lib/std/crypto/kyber.zig
+++ b/lib/std/crypto/kyber.zig
@@ -173,7 +173,7 @@ const common_shared_key_size: usize = 32;
 
 fn Kyber(comptime p: Params) type {
     return struct {
-        // Size of ciphertexts.
+        // Size of a ciphertext, in bytes.
         pub const ciphertext_length = Poly.compressedSize(p.du) * p.k + Poly.compressedSize(p.dv);
 
         const Self = @This();
@@ -323,7 +323,7 @@ fn Kyber(comptime p: Params) type {
             /// Create a new key pair.
             /// If seed is null, a random seed will be generated.
             /// If a seed is provided, the key pair will be determinsitic.
-            pub fn create(seed_: ?[seed_length]u8) KeyPair {
+            pub fn create(seed_: ?[seed_length]u8) !KeyPair {
                 const seed = seed_ orelse sk: {
                     var random_seed: [seed_length]u8 = undefined;
                     crypto.random.bytes(&random_seed);
@@ -1690,7 +1690,7 @@ test "Test happy flow" {
         i = 0;
         while (i < 100) : (i += 1) {
             seed[0] = @intCast(u8, i);
-            var kp = mode.KeyPair.create(seed);
+            var kp = try mode.KeyPair.create(seed);
             const sk = mode.SecretKey.unpack(&kp.secret_key.pack());
             try testing.expectEqual(sk, kp.secret_key);
             const pk = mode.PublicKey.unpack(&kp.public_key.pack());
@@ -1742,7 +1742,7 @@ test "NIST KAT test" {
             g2.fill(kseed[0..32]);
             g2.fill(kseed[32..64]);
             g2.fill(&eseed);
-            const kp = mode.KeyPair.create(kseed);
+            const kp = try mode.KeyPair.create(kseed);
             var ct: [mode.ciphertext_length]u8 = undefined;
             var ss: [mode.shared_length]u8 = undefined;
             kp.public_key.encapsDeterministically(&eseed, &ct, &ss);


### PR DESCRIPTION
- Variable names are snake_case
- Types names are PascalCase
- Make constants for lengths consistent with other similar functions, (ex: dh.X25519)
- PrivateKey -> SecretKey, also for consistency with the rest of the standard library (and to make the `pk` reduction less confusing)
- KeyPair.create() to create deterministic and randomized key pairs.

The number of bits in `usize` should be `Log2Int(usize)` to avoid portability issues with different `usize` sizes.