### PR TITLE
Some more minor changes for consistency with the rest of stdlib

### DIFF
--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -212,17 +212,13 @@ const kems = [_]Crypto{
 pub fn benchmarkKem(comptime Kem: anytype, comptime kems_count: comptime_int) !u64 {
     const key_pair = try Kem.KeyPair.create(null);
 
-    var ct: [Kem.ciphertext_length]u8 = undefined;
-    var ss: [Kem.shared_length]u8 = undefined;
-
     var timer = try Timer.start();
     const start = timer.lap();
     {
         var i: usize = 0;
         while (i < kems_count) : (i += 1) {
-            _ = key_pair.public_key.encaps(&ct, &ss);
-            mem.doNotOptimizeAway(&ct);
-            mem.doNotOptimizeAway(&ss);
+            const e = key_pair.public_key.encaps(null);
+            mem.doNotOptimizeAway(&e);
         }
     }
     const end = timer.read();
@@ -236,16 +232,14 @@ pub fn benchmarkKem(comptime Kem: anytype, comptime kems_count: comptime_int) !u
 pub fn benchmarkKemDecaps(comptime Kem: anytype, comptime kems_count: comptime_int) !u64 {
     const key_pair = try Kem.KeyPair.create(null);
 
-    var ct: [Kem.ciphertext_length]u8 = undefined;
-    var ss: [Kem.shared_length]u8 = undefined;
-    _ = key_pair.public_key.encaps(&ct, &ss);
+    const e = key_pair.public_key.encaps(null);
 
     var timer = try Timer.start();
     const start = timer.lap();
     {
         var i: usize = 0;
         while (i < kems_count) : (i += 1) {
-            const ss2 = key_pair.secret_key.decaps(&ct);
+            const ss2 = key_pair.secret_key.decaps(&e.ciphertext);
             mem.doNotOptimizeAway(&ss2);
         }
     }

--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -239,7 +239,7 @@ pub fn benchmarkKemDecaps(comptime Kem: anytype, comptime kems_count: comptime_i
     {
         var i: usize = 0;
         while (i < kems_count) : (i += 1) {
-            const ss2 = key_pair.secret_key.decaps(&e.ciphertext);
+            const ss2 = try key_pair.secret_key.decaps(&e.ciphertext);
             mem.doNotOptimizeAway(&ss2);
         }
     }

--- a/lib/std/crypto/benchmark.zig
+++ b/lib/std/crypto/benchmark.zig
@@ -549,7 +549,7 @@ pub fn main() !void {
 
     inline for (kems) |E| {
         if (filter == null or std.mem.indexOf(u8, E.name, filter.?) != null) {
-            const throughput = try benchmarkKemDecaps(E.ty, mode(1000));
+            const throughput = try benchmarkKemDecaps(E.ty, mode(25000));
             try stdout.print("{s:>17}: {:10} decaps/s\n", .{ E.name, throughput });
         }
     }

--- a/lib/std/crypto/kyber.zig
+++ b/lib/std/crypto/kyber.zig
@@ -1157,7 +1157,7 @@ const Poly = struct {
         comptime var batch_bytes: usize = undefined;
         comptime var mask: T = 0;
         comptime {
-            batch_count = @divTrunc(@typeInfo(T).Int.bits, 2 * eta);
+            batch_count = @divTrunc(@bitSizeOf(T), 2 * eta);
             while (@rem(N, batch_count) != 0 and batch_count > 0) : (batch_count -= 1) {}
             assert(batch_count > 0);
             assert(@rem(2 * eta * batch_count, 8) == 0);

--- a/lib/std/crypto/kyber.zig
+++ b/lib/std/crypto/kyber.zig
@@ -1430,13 +1430,13 @@ fn Mat(comptime K: u8) type {
 }
 
 // Returns `true` if a ≠ b.
-fn ctneq(comptime len: usize, a: [len]u8, b: [len]u8) bool {
-    return !crypto.utils.timingSafeEql([len]u8, a, b);
+fn ctneq(comptime len: usize, a: [len]u8, b: [len]u8) u1 {
+    return 1 - @boolToInt(crypto.utils.timingSafeEql([len]u8, a, b));
 }
 
 // Copy src into dst given b = 1.
-fn cmov(comptime len: usize, dst: *[len]u8, src: [len]u8, b: bool) void {
-    const mask = @as(u8, 0) -% @boolToInt(b);
+fn cmov(comptime len: usize, dst: *[len]u8, src: [len]u8, b: u1) void {
+    const mask = @as(u8, 0) -% b;
     for (0..len) |i| {
         dst[i] ^= mask & (dst[i] ^ src[i]);
     }

--- a/lib/std/crypto/kyber.zig
+++ b/lib/std/crypto/kyber.zig
@@ -767,7 +767,7 @@ const Poly = struct {
 
     fn add(a: Poly, b: Poly) Poly {
         var ret: Poly = undefined;
-        inline for (0..N) |i| {
+        for (0..N) |i| {
             ret.cs[i] = a.cs[i] + b.cs[i];
         }
         return ret;
@@ -775,7 +775,7 @@ const Poly = struct {
 
     fn sub(a: Poly, b: Poly) Poly {
         var ret: Poly = undefined;
-        inline for (0..N) |i| {
+        for (0..N) |i| {
             ret.cs[i] = a.cs[i] - b.cs[i];
         }
         return ret;
@@ -785,7 +785,7 @@ const Poly = struct {
     // coefficient |x| ≤ q.
     fn randAbsLeqQ(rnd: anytype) Poly {
         var ret: Poly = undefined;
-        inline for (0..N) |i| {
+        for (0..N) |i| {
             ret.cs[i] = rnd.random().intRangeAtMost(i16, -Q, Q);
         }
         return ret;
@@ -794,7 +794,7 @@ const Poly = struct {
     // For testing, generates a random normalized polynomial.
     fn randNormalized(rnd: anytype) Poly {
         var ret: Poly = undefined;
-        inline for (0..N) |i| {
+        for (0..N) |i| {
             ret.cs[i] = rnd.random().intRangeLessThan(i16, 0, Q);
         }
         return ret;

--- a/lib/std/crypto/kyber.zig
+++ b/lib/std/crypto/kyber.zig
@@ -200,7 +200,7 @@ fn Kyber(comptime p: Params) type {
             hpk: [h_length]u8, // H(pk)
 
             /// Size of a serialized representation of the key, in bytes.
-            pub const compressed_length: usize = InnerPk.compressed_length;
+            pub const compressed_length = InnerPk.compressed_length;
 
             /// Generates a shared secret, and encapsulates it for the public key.
             /// If `seed` is `null`, a random seed is used. This is recommended.
@@ -367,7 +367,7 @@ fn Kyber(comptime p: Params) type {
             // Cached values
             aT: M,
 
-            const compressed_length: usize = V.compressed_length + 32;
+            const compressed_length = V.compressed_length + 32;
 
             fn encrypt(
                 pk: InnerPk,
@@ -558,7 +558,7 @@ test "invNTTReductions bounds" {
         }
 
         while (true) {
-            const j: i16 = inv_ntt_reductions[r];
+            const j = inv_ntt_reductions[r];
             r += 1;
             if (j < 0) {
                 break;
@@ -599,7 +599,7 @@ fn invertMod(a: anytype, p: @TypeOf(a)) @TypeOf(a) {
 
 // Reduce mod q for testing.
 fn modQ32(x: i32) i16 {
-    var y: i16 = @intCast(i16, @rem(x, @as(i32, Q)));
+    var y = @intCast(i16, @rem(x, @as(i32, Q)));
     if (y < 0) {
         y += Q;
     }
@@ -622,7 +622,7 @@ fn montReduce(x: i32) i16 {
     // Note that x q' might be as big as 2³² and could overflow the int32
     // multiplication in the last line.  However for any int32s a and b,
     // we have int32(int64(a)*int64(b)) = int32(a*b) and so the result is ok.
-    const m: i16 = @truncate(i16, @truncate(i32, x *% qInv));
+    const m = @truncate(i16, @truncate(i32, x *% qInv));
 
     // Note that x - m q is divisable by R; indeed modulo R we have
     //
@@ -642,9 +642,9 @@ fn montReduce(x: i32) i16 {
 test "Test montReduce" {
     var rnd = RndGen.init(0);
     for (0..1000) |_| {
-        const bound: i32 = comptime @as(i32, Q) * (1 << 15);
-        const x: i32 = rnd.random().intRangeLessThan(i32, -bound, bound);
-        const y: i16 = montReduce(x);
+        const bound = comptime @as(i32, Q) * (1 << 15);
+        const x = rnd.random().intRangeLessThan(i32, -bound, bound);
+        const y = montReduce(x);
         try testing.expect(-Q < y and y < Q);
         try testing.expectEqual(modQ32(x), modQ32(@as(i32, y) * R));
     }
@@ -660,7 +660,7 @@ fn feToMont(x: i16) i16 {
 test "Test feToMont" {
     var x: i32 = -(1 << 15);
     while (x < 1 << 15) : (x += 1) {
-        const y: i16 = feToMont(@intCast(i16, x));
+        const y = feToMont(@intCast(i16, x));
         try testing.expectEqual(modQ32(@as(i32, y)), modQ32(x * r_mod_q));
     }
 }
@@ -693,8 +693,8 @@ fn feBarrettReduce(x: i16) i16 {
 test "Test Barrett reduction" {
     var x: i32 = -(1 << 15);
     while (x < 1 << 15) : (x += 1) {
-        var y1: i16 = feBarrettReduce(@intCast(i16, x));
-        const y2: i16 = @mod(@intCast(i16, x), Q);
+        var y1 = feBarrettReduce(@intCast(i16, x));
+        const y2 = @mod(@intCast(i16, x), Q);
         if (x < 0 and @rem(-x, Q) == 0) {
             y1 -= Q;
         }
@@ -713,8 +713,8 @@ fn csubq(x: i16) i16 {
 test "Test csubq" {
     var x: i32 = -29439;
     while (x < 1 << 15) : (x += 1) {
-        const y1: i16 = csubq(@intCast(i16, x));
-        var y2: i16 = @intCast(i16, x);
+        const y1 = csubq(@intCast(i16, x));
+        var y2 = @intCast(i16, x);
         if (@intCast(i16, x) >= Q) {
             y2 -= Q;
         }
@@ -1015,10 +1015,10 @@ const Poly = struct {
             inline while (i < in_batch_size) : (j += 1) {
                 comptime var todo: usize = 8;
                 inline while (todo > 0) {
-                    const out_shift: usize = comptime 8 - todo;
+                    const out_shift = comptime 8 - todo;
                     out[out_off + j] |= @truncate(u8, (in[i] >> in_shift) << out_shift);
 
-                    const done: usize = comptime @min(@min(d, todo), d - in_shift);
+                    const done = comptime @min(@min(d, todo), d - in_shift);
                     todo -= done;
                     in_shift += done;
 
@@ -1039,7 +1039,7 @@ const Poly = struct {
     // Set p to Decompress_q(m, d).
     fn decompress(comptime d: u8, in: *const [compressedSize(d)]u8) Poly {
         @setEvalBranchQuota(10000);
-        const inLen: usize = comptime @divTrunc(N * d, 8);
+        const inLen = comptime @divTrunc(N * d, 8);
         comptime assert(inLen * 8 == d * N);
         var ret: Poly = undefined;
         var in_off: usize = 0;
@@ -1055,15 +1055,15 @@ const Poly = struct {
             comptime var i: usize = 0;
             inline while (i < out_batch_size) : (i += 1) {
                 // First, unpack next coefficient.
-                comptime var todo: usize = d;
+                comptime var todo = d;
                 var out: u16 = 0;
 
                 inline while (todo > 0) {
-                    const out_shift: usize = comptime d - todo;
+                    const out_shift = comptime d - todo;
                     const m = comptime (1 << d) - 1;
                     out |= (@as(u16, in[in_off + j] >> in_shift) << out_shift) & m;
 
-                    const done: usize = comptime @min(@min(8, todo), 8 - in_shift);
+                    const done = comptime @min(@min(8, todo), 8 - in_shift);
                     todo -= done;
                     in_shift += done;
 

--- a/lib/std/crypto/kyber.zig
+++ b/lib/std/crypto/kyber.zig
@@ -1656,13 +1656,13 @@ test "NIST KAT test" {
         }
         var f = sha2.Sha256.init(.{});
         const fw = f.writer();
-        var g = NistDRBG.new(seed);
+        var g = NistDRBG.init(seed);
         try std.fmt.format(fw, "# {s}\n\n", .{mode.name});
         for (0..100) |i| {
             g.fill(&seed);
             try std.fmt.format(fw, "count = {}\n", .{i});
             try std.fmt.format(fw, "seed = {s}\n", .{std.fmt.fmtSliceHexUpper(&seed)});
-            var g2 = NistDRBG.new(seed);
+            var g2 = NistDRBG.init(seed);
 
             // This is not equivalent to g2.fill(kseed[:]).  As the reference
             // implementation calls randombytes twice generating the keypair,
@@ -1745,9 +1745,8 @@ const NistDRBG = struct {
         g.update(null);
     }
 
-    // randombyte_init(seed, NULL, 256).
-    fn new(seed: [48]u8) NistDRBG {
-        var ret: NistDRBG = NistDRBG{ .key = .{0} ** 32, .v = .{0} ** 16 };
+    fn init(seed: [48]u8) NistDRBG {
+        var ret: NistDRBG = .{ .key = .{0} ** 32, .v = .{0} ** 16 };
         ret.update(seed);
         return ret;
     }


### PR DESCRIPTION
Some more minor changes for consistency with the rest of stdlib

- Replace while() loops with for() loops
- Make `encaps()` return a structure rather than take pointers, and the optional seed
- Constify a few variables
- `pack()/unpack()` -> `fromBytes()/toBytes()`